### PR TITLE
Add some notes and Gemfile.lock to prevent people from upgrading to newer, incompatible versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-
-Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'sinatra'
-gem 'opal-phaser', git: 'https://github.com/orbitalimpact/opal-phaser.git'
+gem 'opal-phaser', git: 'https://github.com/orbitalimpact/opal-phaser.git', ref: "7fb55a64170bd2c3c88abd7979b00249f53367f3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,35 @@
+GIT
+  remote: https://github.com/orbitalimpact/opal-phaser.git
+  revision: 7fb55a64170bd2c3c88abd7979b00249f53367f3
+  ref: 7fb55a64170bd2c3c88abd7979b00249f53367f3
+  specs:
+    opal-phaser (0.1.6)
+      opal
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    hike (1.2.3)
+    opal (0.7.1)
+      hike (~> 1.2)
+      sourcemap (~> 0.1.0)
+      sprockets (~> 2.12.3)
+      tilt (>= 1.4)
+    rack (1.6.0)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sourcemap (0.1.1)
+    sprockets (3.4.0)
+      rack (> 1, < 3)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  opal-phaser!
+  sinatra

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Based on https://github.com/deiga/phaser-pong
 ## Running
 
 ```
- $ bundle
- $ rackup
+ $ # don't bother running `bundle` because the project will upgrade to newer, incompatible versions
+ $ bundle exec rackup
 ```
 
 ## Contributing


### PR DESCRIPTION
Hi @ndrluis,
You might have noticed that there have been a lot of API changes in opal-phaser since this project was created, so I unignored the `Gemfile.lock` and added a note in the README to keep people from upgrading to versions that will break this project under its current API.